### PR TITLE
Add meta descriptions and lazy image loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="description" content="The DC Privacy Summit convenes technologists, privacy advocates and policymakers to explore innovations in privacy technology.">
 <link rel="stylesheet" href="./fonts/fontawesome/css/all.min.css" />	
 <link href="./favicon.ico" rel="icon" type="image/x-icon"/>
 <link href="./css/styles.css" rel="stylesheet">
@@ -92,142 +93,142 @@
     <p>An elite lineup of experts in policy and privacy.</p>
     <div class="team-grid">
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Carole.webp" alt="Carole House">
+        <img loading="lazy" src="./images/2024/speakers/Carole.webp" alt="Carole House">
         <h4>Carole House</h4>
         <p>Special Advisor, White House NSC</p>
       </div>
 	      <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Faryar.webp" alt="Faryar Shirzad">
+        <img loading="lazy" src="./images/2024/speakers/Faryar.webp" alt="Faryar Shirzad">
         <h4>Faryar Shirzad</h4>
         <p>Chief Policy Officer, Coinbase</p>
       </div>	
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Michael.webp" alt="Michael Mosier">
+        <img loading="lazy" src="./images/2024/speakers/Michael.webp" alt="Michael Mosier">
         <h4>Michael Mosier</h4>
         <p>Co-Founder, Arktouros pllc</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Rebecca.webp" alt="Rebecca Rettig">
+        <img loading="lazy" src="./images/2024/speakers/Rebecca.webp" alt="Rebecca Rettig">
         <h4>Rebecca Rettig</h4>
         <p>Chief Legal &amp; Policy Officer, Polygon Labs</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Josh.webp" alt="Josh Swihart">
+        <img loading="lazy" src="./images/2024/speakers/Josh.webp" alt="Josh Swihart">
         <h4>Josh Swihart</h4>
         <p>CEO, Electric Coin Company, creators and supporters of Zcash</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Marta.webp" alt="Marta Belcher">
+        <img loading="lazy" src="./images/2024/speakers/Marta.webp" alt="Marta Belcher">
         <h4>Marta Belcher</h4>
         <p>President and Chair, Filecoin Foundation and Filecoin Foundation for the Decentralized Web</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Nikhil.webp" alt="Nikhil Raghuveera">
+        <img loading="lazy" src="./images/2024/speakers/Nikhil.webp" alt="Nikhil Raghuveera">
         <h4>Nikhil Raghuveera</h4>
         <p>CEO, Predicate</p>
       </div>
         <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Michele.webp" alt="Michele Korver">
+        <img loading="lazy" src="./images/2024/speakers/Michele.webp" alt="Michele Korver">
         <h4>Michele Korver</h4>
         <p>Head of Regulatory, a16z crypto</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Shashank.webp" alt="Shashank Agrawal">
+        <img loading="lazy" src="./images/2024/speakers/Shashank.webp" alt="Shashank Agrawal">
         <h4>Shashank Agrawal</h4>
         <p>Blockchain Security Research Engineering Manager, Coinbase</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Tony.webp" alt="Tony Johnson">
+        <img loading="lazy" src="./images/2024/speakers/Tony.webp" alt="Tony Johnson">
         <h4>Tony Johnson</h4>
         <p>President &amp; CEO, Truman Center</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Asha.webp" alt="Asha Shankar">
+        <img loading="lazy" src="./images/2024/speakers/Asha.webp" alt="Asha Shankar">
         <h4>Asha Shankar</h4>
         <p>Privacy Program Management, Coinbase</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Stanley.webp" alt="Jay Stanley">
+        <img loading="lazy" src="./images/2024/speakers/Stanley.webp" alt="Jay Stanley">
         <h4>Jay Stanley</h4>
         <p>Speech, Privacy and Technology Project, American Civil Liberties Union</p>
       </div>
     
 	<div class="team-card fade-init">
-        <img src="./images/2024/speakers/Leena.webp" alt="Leena Im">
+        <img loading="lazy" src="./images/2024/speakers/Leena.webp" alt="Leena Im">
         <h4>Leena Im</h4>
         <p>VP Policy and Chief Strategy Officer, Aleo Ventures</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Allison.webp" alt="Allison Behuniak">
+        <img loading="lazy" src="./images/2024/speakers/Allison.webp" alt="Allison Behuniak">
         <h4>Allison Behuniak</h4>
         <p>Staff Director, US House Financial Services Committee</p>
       </div>  		
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Zak.webp" alt="Zak Cole">
+        <img loading="lazy" src="./images/2024/speakers/Zak.webp" alt="Zak Cole">
         <h4>Zak Cole</h4>
         <p>Cofounder, 0xbow</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/PaulBrigner.webp" alt="Paul Brigner">
+        <img loading="lazy" src="./images/2024/speakers/PaulBrigner.webp" alt="Paul Brigner">
         <h4>Paul Brigner</h4>
         <p>Head of Coinbase Institute</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Ameen.webp" alt="Ameen Soleimani">
+        <img loading="lazy" src="./images/2024/speakers/Ameen.webp" alt="Ameen Soleimani">
         <h4>Ameen Soleimani</h4>
         <p>Strategic Advisor, 0xbow</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Katherine.webp" alt="Katherine Kirkpatrick Bos">
+        <img loading="lazy" src="./images/2024/speakers/Katherine.webp" alt="Katherine Kirkpatrick Bos">
         <h4>Katherine Kirkpatrick Bos</h4>
         <p>General Counsel, Starkware</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Justin.webp" alt="Justin Thaler">
+        <img loading="lazy" src="./images/2024/speakers/Justin.webp" alt="Justin Thaler">
         <h4>Justin Thaler</h4>
         <p>Research Partner, a16z</p>
       </div>      <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Peter.webp" alt="Peter Van Valkenburgh">
+        <img loading="lazy" src="./images/2024/speakers/Peter.webp" alt="Peter Van Valkenburgh">
         <h4>Peter Van Valkenburgh</h4>
         <p>Research Director, Coin Center</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Eric.webp" alt="Eric Chung">
+        <img loading="lazy" src="./images/2024/speakers/Eric.webp" alt="Eric Chung">
         <h4>Eric Chung</h4>
         <p>Managing Director, USC VanEck Digital Assets (VEDA) Initiative</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Zooko.webp" alt="Zooko Wilcox">
+        <img loading="lazy" src="./images/2024/speakers/Zooko.webp" alt="Zooko Wilcox">
         <h4>Zooko Wilcox</h4>
         <p>Head of Product, Shielded Labs</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/PaulBrody.webp" alt="Paul Brody">
+        <img loading="lazy" src="./images/2024/speakers/PaulBrody.webp" alt="Paul Brody">
         <h4>Paul Brody</h4>
         <p>Global Blockchain Leader, EY</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Miller.webp" alt="Miller Whitehouse‑Levine">
+        <img loading="lazy" src="./images/2024/speakers/Miller.webp" alt="Miller Whitehouse‑Levine">
         <h4>Miller Whitehouse‑Levine</h4>
         <p>CEO, DeFi Education Fund</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Mike.webp" alt="Mike Orcutt">
+        <img loading="lazy" src="./images/2024/speakers/Mike.webp" alt="Mike Orcutt">
         <h4>Mike Orcutt</h4>
         <p>Journalist and Editor, Project Glitch</p>
       </div>      
 	<div class="team-card fade-init">
-        <img src="./images/2024/speakers/Casey.webp" alt="Casey Wagner">
+        <img loading="lazy" src="./images/2024/speakers/Casey.webp" alt="Casey Wagner">
         <h4>Casey Wagner</h4>
         <p>Senior Reporter, Blockworks</p>
       </div>
       <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Nikhilesh.webp" alt="Nikhilesh De">
+        <img loading="lazy" src="./images/2024/speakers/Nikhilesh.webp" alt="Nikhilesh De">
         <h4>Nikhilesh De</h4>
         <p>Managing Editor for Global Policy and Regulation, CoinDesk</p>
       </div>
 	      <div class="team-card fade-init">
-        <img src="./images/2024/speakers/Michael.webp" alt="Michael Reilly">
+        <img loading="lazy" src="./images/2024/speakers/Michael.webp" alt="Michael Reilly">
         <h4>Michael Reilly</h4>
         <p>Editor, Project Glitch</p>
       </div>		
@@ -241,10 +242,10 @@
     <h2 class="lined-heading">Sponsors</h2>
     <p>Join a community committed to advancing privacy and technology.</p>
     <div class="sponsor-grid">
-      <a href="https://www.projectglitch.xyz/" target="_blank" rel="noopener noreferrer" ><img src="./images/2024/sponsors/glitch_sponsor.png" alt="Project Glitch logo"></a>
-      <a href="https://www.pgpforcrypto.org" target="_blank" rel="noopener noreferrer" ><img src="./images/2024/sponsors/pgp_sponsor.png" alt="PGP for Crypto logo"></a>
-      <a href="https://brownrudnick.com/" target="_blank" rel="noopener noreferrer" ><img src="./images/2024/sponsors/brownrudnik_sponsor.png" alt="Brown Rudnick logo"></a>
-      <a href="https://aleo.org" target="_blank" rel="noopener noreferrer" ><img src="./images/2024/sponsors/aleo_sponsor.png" alt="Aleo logo"></a>
+      <a href="https://www.projectglitch.xyz/" target="_blank" rel="noopener noreferrer" ><img loading="lazy" src="./images/2024/sponsors/glitch_sponsor.png" alt="Project Glitch logo"></a>
+      <a href="https://www.pgpforcrypto.org" target="_blank" rel="noopener noreferrer" ><img loading="lazy" src="./images/2024/sponsors/pgp_sponsor.png" alt="PGP for Crypto logo"></a>
+      <a href="https://brownrudnick.com/" target="_blank" rel="noopener noreferrer" ><img loading="lazy" src="./images/2024/sponsors/brownrudnik_sponsor.png" alt="Brown Rudnick logo"></a>
+      <a href="https://aleo.org" target="_blank" rel="noopener noreferrer" ><img loading="lazy" src="./images/2024/sponsors/aleo_sponsor.png" alt="Aleo logo"></a>
     </div>
 	  <div style="text-align:center">
     <p style="margin-top:30px"><a href="mailto:sponsor@dcprivacysummit.org" class="btn" >Sponsorship Opportunities</a></p>
@@ -260,9 +261,9 @@
 
 <!-- in your HTML -->
 <div class="venue-gallery">
-  <img src="./images/venue/usc_capital_campus.png" alt="Venue exterior">
-  <img src="./images/venue/usc_conference_center.png" alt="Main hall interior">
-  <img src="./images/venue/usc_rooftop.png"    alt="Rooftop terrace">
+  <img loading="lazy" src="./images/venue/usc_capital_campus.png" alt="Venue exterior">
+  <img loading="lazy" src="./images/venue/usc_conference_center.png" alt="Main hall interior">
+  <img loading="lazy" src="./images/venue/usc_rooftop.png"    alt="Rooftop terrace">
 </div>
 	  
 
@@ -304,7 +305,7 @@
 <footer id="contact">
   <div class="container footer-grid">
     <div>
-      <img src="./images/logo-privacy.webp" alt="DC Privacy Summit logo" style="max-width:220px">
+      <img loading="lazy" src="./images/logo-privacy.webp" alt="DC Privacy Summit logo" style="max-width:220px">
       <p style="margin-top:10px">Where Privacy, Innovation, and Policy Converge</p>
     </div>
     <div>

--- a/live-stream/index.html
+++ b/live-stream/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Video archive of the 2024 DC Privacy Summit sessions." >
   <link href="../favicon.ico" rel="icon" type="image/x-icon"/>
   <title>2024 Summit Videos – DC Privacy Summit</title>
   <!-- Google Fonts -->


### PR DESCRIPTION
## Summary
- add meta description tag to `<head>` in both pages
- lazy-load non-critical images on homepage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688287f859588321a827afc2252603a2