### PR TITLE
fetch protected refs before promotion

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,6 +150,7 @@ jobs:
           fi
 
           if [ "$current_main_sha" != "$STAGING_SHA" ]; then
+            git fetch --no-tags origin main staging
             git push origin "$STAGING_SHA:refs/heads/main"
           fi
 


### PR DESCRIPTION
## What changed

- fetch main and staging in the production job before the deploy-key push

## Why

The checkout is intentionally shallow. Without the protected refs in the local graph, Git rejected the otherwise valid fast-forward before the server evaluated the ruleset.

## Checks

- actionlint
- git diff --check
