### PR TITLE
use full history for protected promotion

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,6 +127,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           ref: ${{ needs.verify-promotion.outputs.staging_sha }}
           ssh-key: ${{ secrets.MAIN_PROMOTION_DEPLOY_KEY }}
 


### PR DESCRIPTION
## What changed

- fetch complete history in the production checkout

## Why

Git must see the complete main-to-staging ancestry before it will issue the deploy-key fast-forward to the protected branch.

## Checks

- actionlint
- git diff --check
